### PR TITLE
Migrate build to buildkite and add some more packages to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,10 @@ RUN apt-get update && apt-get install -y \
 RUN install_packages --repo=https://vimc.github.io/drat \
     car \
     data.table \
+    DBI \
+    dbplyr \
     dplyr \
     jenner \
     rlist \
-    stringr
+    stringr \
+    testthat 

--- a/README.md
+++ b/README.md
@@ -42,3 +42,4 @@ Options:
 ```
 
 (note that here `PATH` is the path in the container).
+

--- a/buildkite/pipeline.yml
+++ b/buildkite/pipeline.yml
@@ -1,0 +1,8 @@
+steps:
+  - label: ":whale: Build"
+    command: build
+
+  - wait
+
+  - label: ":shipit: Push images"
+    command: push

--- a/common
+++ b/common
@@ -3,8 +3,20 @@ PACKAGE_ROOT=$(realpath $HERE)
 PACKAGE_NAME=montagu-dettl
 PACKAGE_ORG=vimc
 
-GIT_SHA=$(git -C "$PACKAGE_ROOT" rev-parse --short=7 HEAD)
-GIT_BRANCH=$(git -C "$PACKAGE_ROOT" symbolic-ref --short HEAD)
+# Buildkite doesn't check out a full history from the remote (just the
+# single commit) so you end up with a detached head and git rev-parse
+# doesn't work
+if [ "$BUILDKITE" = "true" ]; then
+    GIT_SHA=${BUILDKITE_COMMIT:0:7}
+else
+    GIT_SHA=$(git -C "$PACKAGE_ROOT" rev-parse --short=7 HEAD)
+fi
+
+if [ "$BUILDKITE" = "true" ]; then
+    GIT_BRANCH=$BUILDKITE_BRANCH
+else
+    GIT_BRANCH=$(git -C "$PACKAGE_ROOT" symbolic-ref --short HEAD)
+fi
 
 TAG_SHA="${PACKAGE_ORG}/${PACKAGE_NAME}:${GIT_SHA}"
 TAG_BRANCH="${PACKAGE_ORG}/${PACKAGE_NAME}:${GIT_BRANCH}"

--- a/teamcity
+++ b/teamcity
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -e
-HERE=$(dirname $0)
-$HERE/build
-$HERE/push


### PR DESCRIPTION
We need to run latest annex-import on a machine with lots of memory (more than my local machine) we've used this docker build to do it previously but it needs building with an updated version of dettl